### PR TITLE
Use Bundler.settings for disabling warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ otherwise if the options or version specified are significantly different, it
 will use `override_gem`, otherwise it will just do nothing, deferring to the
 original declaration.
 
+## Configuration
+
+To disable warnings that are output to the console when `override_gem` or
+`ensure_gem` is in use, you can update a bundler setting:
+
+```console
+$ bundle config bundler_inject.disable_warn_override_gem true
+```
+
+or use an environment variable:
+
+```console
+$ export BUNDLE_BUNDLER_INJECT__DISABLE_WARN_OVERRIDE_GEM=true
+```
+
+There is a fallback for those that will check the `RAILS_ENV` environment
+variable, and will disable the warning when in `"production"`.
+
 ## What is this sorcery?
 
 While this is technically a bundler plugin, bundler-inject does not use the

--- a/lib/bundler/inject.rb
+++ b/lib/bundler/inject.rb
@@ -1,6 +1,42 @@
 require "bundler/inject/version"
 require "bundler/inject/dsl_patch"
 
+module Bundler
+  module Inject
+    class << self
+      # Check if we should skip outputing warnings
+      #
+      # This can be set in two ways:
+      #
+      #   - Via bundler's Bundler::Settings
+      #   - When RAILS_ENV=production is set
+      #
+      # To configure the setting, you can run:
+      #
+      #   bundle config bundler_inject.disable_warn_override_gem true
+      #
+      # OR use an environment variable
+      #
+      #   BUNDLE_BUNDLER_INJECT__DISABLE_WARN_OVERRIDE_GEM=true bundle ...
+      #
+      # If neither are set, it will check for ENV["RAILS_ENV"] is "production",
+      # and will skip if it is, but the bundler variable is present (and even
+      # set to "false") that will be favored.
+      def skip_warnings?
+        return @skip_warnings if defined?(@skip_warnings)
+
+        bundler_setting = Bundler.settings["bundler_inject.disable_warn_override_gem"]
+
+        if bundler_setting.nil?
+          ENV["RAILS_ENV"] == "production"
+        else
+          bundler_setting
+        end
+      end
+    end
+  end
+end
+
 Bundler::Dsl.prepend(Bundler::Inject::DslPatch)
 ObjectSpace.each_object(Bundler::Dsl) do |o|
   o.singleton_class.prepend(Bundler::Inject::DslPatch)

--- a/lib/bundler/inject/dsl_patch.rb
+++ b/lib/bundler/inject/dsl_patch.rb
@@ -69,7 +69,7 @@ module Bundler
       end
 
       def warn_override_gem(calling_file, name, args)
-        return if Bundler.settings["bundler_inject.disable_warn_override_gem"]
+        return if Bundler::Inject.skip_warnings?
 
         version, opts = extract_version_opts(args)
         message = "** override_gem(#{name.inspect}"

--- a/lib/bundler/inject/dsl_patch.rb
+++ b/lib/bundler/inject/dsl_patch.rb
@@ -69,7 +69,7 @@ module Bundler
       end
 
       def warn_override_gem(calling_file, name, args)
-        return if ENV["RAILS_ENV"] == "production"
+        return if Bundler.settings["bundler_inject.disable_warn_override_gem"]
 
         version, opts = extract_version_opts(args)
         message = "** override_gem(#{name.inspect}"

--- a/spec/bundler_inject_spec.rb
+++ b/spec/bundler_inject_spec.rb
@@ -147,11 +147,12 @@ RSpec.describe Bundler::Inject do
           expect(stream).to include "Trying to override unknown gem \"omg\""
         end
 
-        it "with ENV['RAILS_ENV'] = 'production'" do
+        it "with ENV['BUNDLE_BUNDLER_INJECT__DISABLE_WARN_OVERRIDE_GEM'] = 'true'" do
           write_bundler_d_file <<~F
             override_gem "rack", "=2.0.5"
           F
-          bundle(:update, env: { "RAILS_ENV" => "production" })
+          env_var = "BUNDLE_BUNDLER_INJECT__DISABLE_WARN_OVERRIDE_GEM"
+          bundle(:update, env: { env_var => "true" })
 
           expect(lockfile_specs).to eq [["rack", "2.0.5"]]
           expect(err).to_not match %r{^\*\* override_gem}

--- a/spec/bundler_inject_spec.rb
+++ b/spec/bundler_inject_spec.rb
@@ -146,6 +146,17 @@ RSpec.describe Bundler::Inject do
           stream = bundler_short_version == "2.0" ? err : out
           expect(stream).to include "Trying to override unknown gem \"omg\""
         end
+
+        it "with ENV['RAILS_ENV'] = 'production'" do
+          write_bundler_d_file <<~F
+            override_gem "rack", "=2.0.5"
+          F
+          bundle(:update, env: { "RAILS_ENV" => "production" })
+
+          expect(lockfile_specs).to eq [["rack", "2.0.5"]]
+          expect(err).to_not match %r{^\*\* override_gem}
+        end
+
       end
 
       describe "#ensure_gem" do

--- a/spec/bundler_inject_spec.rb
+++ b/spec/bundler_inject_spec.rb
@@ -158,6 +158,26 @@ RSpec.describe Bundler::Inject do
           expect(err).to_not match %r{^\*\* override_gem}
         end
 
+        it "with ENV['RAILS_ENV'] = 'production'" do
+          write_bundler_d_file <<~F
+            override_gem "rack", "=2.0.5"
+          F
+          bundle(:update, env: { "RAILS_ENV" => "production" })
+
+          expect(lockfile_specs).to eq [["rack", "2.0.5"]]
+          expect(err).to_not match %r{^\*\* override_gem}
+        end
+
+        it "with ENV['RAILS_ENV'] = 'production' and the Bundler::Setting false" do
+          write_bundler_d_file <<~F
+            override_gem "rack", "=2.0.5"
+          F
+          env_var = "BUNDLE_BUNDLER_INJECT__DISABLE_WARN_OVERRIDE_GEM"
+          bundle(:update, env: { "RAILS_ENV" => "production", env_var => 'false' })
+
+          expect(lockfile_specs).to eq [["rack", "2.0.5"]]
+          expect(err).to match %r{^\*\* override_gem\("rack", "=2.0.5"\) at .+/bundler\.d/local_overrides\.rb:1$}
+        end
       end
 
       describe "#ensure_gem" do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -101,16 +101,16 @@ module Spec
       lf.specs.map { |s| [s.name, s.version.to_s] }
     end
 
-    def raw_bundle(command, verbose: false)
+    def raw_bundle(command, verbose: false, env: {})
       command = "bundle #{Helpers.bundler_cli_version} #{command} #{"--verbose" if verbose}".strip
       out, err, process_status = Bundler.with_clean_env do
-        Open3.capture3(command, :chdir => app_dir)
+        Open3.capture3(env, command, :chdir => app_dir)
       end
       return command, out, err, process_status
     end
 
-    def bundle(command, expect_error: false, verbose: false)
-      command, @out, @err, @process_status = raw_bundle(command, verbose: verbose)
+    def bundle(command, expect_error: false, verbose: false, env: {})
+      command, @out, @err, @process_status = raw_bundle(command, verbose: verbose, env: env)
       if expect_error
         expect(@process_status.exitstatus).to_not eq(0), "#{command.inspect} succeeded but was not expected to."
       else


### PR DESCRIPTION
We have better interfaces available in bundler that are not framework specific, so let's use those.

More info in https://github.com/ManageIQ/bundler-inject/issues/5

Fixes https://github.com/ManageIQ/bundler-inject/issues/5


TODO:
-----

* [x] README entry?