### PR TITLE
Fix expand_rack_version looking in wrong file

### DIFF
--- a/bundler-inject.gemspec
+++ b/bundler-inject.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "rubocop-performance"
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -149,7 +149,7 @@ module Spec
         _, path, _, _ = raw_bundle("show rack")
         path = Pathname.new(path.chomp)
       end
-      path.expand_path.join("lib/rack.rb").read[/RELEASE += +([\"\'])([\d][\w\.]+)\1/, 2]
+      path.expand_path.join("lib/rack/version.rb").read[/RELEASE += +([\"\'])([\d][\w\.]+)\1/, 2]
     end
   end
 end


### PR DESCRIPTION
The rack RELEASE constant is in lib/rack/version.rb not lib/rack.rb which causes the following spec failure: https://travis-ci.com/github/ManageIQ/bundler-inject/jobs/356571835#L316-L320