### PR TITLE
support services without a user being set

### DIFF
--- a/lib/bundler/inject/dsl_patch.rb
+++ b/lib/bundler/inject/dsl_patch.rb
@@ -82,7 +82,9 @@ module Bundler
       end
 
       def load_global_bundler_d
-        load_bundler_d(File.join(Dir.home, ".bundler.d"))
+        if ENV["HOME"]
+          load_bundler_d(File.join(Dir.home, ".bundler.d"))
+        end
       end
 
       def load_local_bundler_d(dir)


### PR DESCRIPTION
Typically, ruby is run as a user with a HOME directory.

But for system services, there is no user nor $HOME set.
This was fixed before by setting the HOME.

But as we move away from always pointing to the `root` user,
it has come time to no longer set the HOME variable.

Bundler was throwing an exception because it could not determine the
home directory while bundler-inject is installed

```
bundler: failed to load command: rake (/opt/manageiq/manageiq-gemset/bin/rake)
ArgumentError: couldn't find login name -- expanding `~'
  .bundle/plugin/gems/bundler-inject-1.1.0/lib/bundler/inject/dsl_patch.rb:85:in `home'
  .bundle/plugin/gems/bundler-inject-1.1.0/lib/bundler/inject/dsl_patch.rb:85:in `load_global_bundler_d'
  .bundle/plugin/gems/bundler-inject-1.1.0/lib/bundler/inject/dsl_patch.rb:33:in `to_definition'
  bundler-2.1.4/lib/bundler/dsl.rb:13:in `evaluate'
```