### PR TITLE
drop eol versions of ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,15 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.4.5
-- 2.5.3
+- 2.7.3
+- 3.0.1
 env:
-- TEST_BUNDLER_VERSION=1.15
-- TEST_BUNDLER_VERSION=1.16
-- TEST_BUNDLER_VERSION=1.17
-- TEST_BUNDLER_VERSION=2.0
 - TEST_BUNDLER_VERSION=2.1
+- TEST_BUNDLER_VERSION=2.2
+jobs:
+  include:
+  - rvm: 2.6.7
+    env: TEST_BUNDLER_VERSION=2.0
 before_install:
 - 'echo ''gem: --no-ri --no-rdoc --no-document'' > ~/.gemrc'
 - gem install bundler -v "~> $TEST_BUNDLER_VERSION.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+Version 2.0
+
+# Bundler-inject Changelog
+
+Doing our best at supporting [SemVer](http://semver.org/) with
+a nice looking [Changelog](http://keepachangelog.com).
+
+## Version [HEAD] <sub><sup>now</sub></sup>
+
+## Version [2.0.0] <sub><sup>2021-05-01</sub></sup>
+
+* **BREAKING**: Drops support for bundler below 2.0
+* **BREAKING**: Drops support for Ruby below 2.6
+* Adds support for running as a service (with no user / HOME set)
+
+[HEAD]: https://github.com/ManageIQ/bundler-inject/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/ManageIQ/bundler-inject/compare/v1.1.0...v2.0.0

--- a/bundler-inject.gemspec
+++ b/bundler-inject.gemspec
@@ -12,6 +12,14 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ManageIQ/bundler-inject"
   spec.license       = "Apache-2.0"
 
+  if spec.respond_to?(:metadata=)
+    spec.metadata = {
+      "bug_tracker_uri" => "https://github.com/ManageIQ/bundler-inject/issues",
+      "changelog_uri"   => "https://github.com/ManageIQ/bundler-inject/blob/master/CHANGELOG.md",
+      "source_code_uri" => "https://github.com/ManageIQ/bundler-inject/",
+    }
+  end
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do

--- a/lib/bundler/inject/version.rb
+++ b/lib/bundler/inject/version.rb
@@ -1,5 +1,5 @@
 module Bundler
   module Inject
-    VERSION = "1.1.0"
+    VERSION = "2.0.0"
   end
 end


### PR DESCRIPTION
While I think we should officially drop support for ruby 2.5 and bundler 1.17, having trouble dropping support for it in the grid.

Would prefer a smaller grid though - don't think it is productive to put so many version in there unless we have reason to believe that a particular version would give us problems.