### PR TITLE
Fix issue where backup is deleted

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -40,13 +40,17 @@ module Spec
     end
 
     def self.backup_global_bundler_d
+      return unless global_bundler_d_dir.exist?
+
       FileUtils.rm_rf(global_bundler_d_backup_dir)
-      FileUtils.mv(global_bundler_d_dir, global_bundler_d_backup_dir) if global_bundler_d_dir.exist?
+      FileUtils.mv(global_bundler_d_dir, global_bundler_d_backup_dir)
     end
 
     def self.restore_global_bundler_d
+      return unless global_bundler_d_backup_dir.exist?
+
       FileUtils.rm_rf(global_bundler_d_dir)
-      FileUtils.mv(global_bundler_d_backup_dir, global_bundler_d_dir) if global_bundler_d_backup_dir.exist?
+      FileUtils.mv(global_bundler_d_backup_dir, global_bundler_d_dir)
     end
 
     attr_reader :out, :err, :process_status


### PR DESCRIPTION
The restore step deletes the .bundler.d directory because it thinks it's
the one created as part of the tests.  However, if a failure occurs
before the backup happens, then this is deleting the real .bundler.d
directory.  This fix prevents that from happening.

@kbrock Please review.