### PR TITLE
Remove remnants of bundler 1.x support

### DIFF
--- a/spec/bundler_inject_spec.rb
+++ b/spec/bundler_inject_spec.rb
@@ -143,8 +143,7 @@ RSpec.describe Bundler::Inject do
           F
           bundle(:update, expect_error: true)
 
-          stream = bundler_short_version.split(".").first == "1" ? out : err
-          expect(stream).to include "Trying to override unknown gem \"omg\""
+          expect(err).to include "Trying to override unknown gem \"omg\""
         end
 
         it "with ENV['BUNDLE_BUNDLER_INJECT__DISABLE_WARN_OVERRIDE_GEM'] = 'true'" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |config|
     end
 
     puts
+    puts "Detected bundler versions: #{Spec::Helpers.bundler_versions.join(", ")}".light_yellow
     puts "Using bundler #{Spec::Helpers.bundler_version}".light_yellow
 
     Spec::Helpers.backup_global_bundler_d

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,14 +3,21 @@ require "open3"
 
 module Spec
   module Helpers
-    def self.bundler_version
-      return @bundler_version if defined?(@bundler_version)
-      versions = Bundler.with_clean_env do
+    def self.bundler_versions
+      @bundler_versions ||= Bundler.with_clean_env do
         `gem list bundler`.lines.grep(/^bundler /).first.scan(/\d+\.\d+\.\d+/)
       end
+    end
+
+    def self.bundler_version
+      return @bundler_version if defined?(@bundler_version)
+
+      versions = bundler_versions
+
       to_find = ENV["TEST_BUNDLER_VERSION"] || ENV["BUNDLER_VERSION"]
-      @bundler_version = versions.detect { |v| v.include?(to_find) }
-      raise "Unable to find bundler version: #{to_find.inspect}" if @bundler_version.nil?
+      @bundler_version = versions.detect { |v| v.start_with?(to_find.to_s) }
+      raise ArgumentError, "Unable to find bundler version: #{to_find.inspect}" if @bundler_version.nil?
+
       @bundler_version
     end
 


### PR DESCRIPTION
If the code was previously bundled with 1.17, the tests will try to run
with 1.17 locally.  This change ensures that locally it runs with the
latest installed bundler.

Additionally, one spec was written with multiple versions in mind, which
we can now drop.

Build on top of #21 

@kbrock Please review.