### PR TITLE
Fix detection of bundler version

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |config|
     end
 
     puts
+    puts "Detected bundler versions: #{Spec::Helpers.bundler_versions.join(", ")}".light_yellow
     puts "Using bundler #{Spec::Helpers.bundler_version}".light_yellow
 
     Spec::Helpers.backup_global_bundler_d

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,14 +3,21 @@ require "open3"
 
 module Spec
   module Helpers
-    def self.bundler_version
-      return @bundler_version if defined?(@bundler_version)
-      versions = Bundler.with_clean_env do
+    def self.bundler_versions
+      @bundler_versions ||= Bundler.with_clean_env do
         `gem list bundler`.lines.grep(/^bundler /).first.scan(/\d+\.\d+\.\d+/)
       end
+    end
+
+    def self.bundler_version
+      return @bundler_version if defined?(@bundler_version)
+
+      versions = bundler_versions
+
       to_find = ENV["TEST_BUNDLER_VERSION"] || ENV["BUNDLER_VERSION"]
-      @bundler_version = versions.detect { |v| v.include?(to_find) }
-      raise "Unable to find bundler version: #{to_find.inspect}" if @bundler_version.nil?
+      @bundler_version = versions.detect { |v| v.start_with?(to_find.to_s) }
+      raise ArgumentError, "Unable to find bundler version: #{to_find.inspect}" if @bundler_version.nil?
+
       @bundler_version
     end
 


### PR DESCRIPTION
This commit fixes a bug based on the partial matching to detect the bundler
version.  Previously a simple substring comparison was done, but then "2.1"
would match "2.2.15", which is wrong.

Example of an invalid run: https://travis-ci.com/github/ManageIQ/bundler-inject/jobs/502898276#L341  (Notice this should test 2.1, but is actually running 2.2)

@kbrock Please review.