### PR TITLE
Update workflow to use latest bundler minor versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,12 @@ jobs:
         - '2.7'
         - '3.0'
         bundler-version:
-        - '2.1.4'
-        - '2.2.33'
-        - '2.3.10'
+        - '2.1'
+        - '2.2'
+        - '2.3'
         include:
         - ruby-version: '2.6'
-          bundler-version: '2.0.2'
+          bundler-version: '2.0'
     env:
       TEST_BUNDLER_VERSION: ${{ matrix.bundler-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
@@ -35,6 +35,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' && matrix.bundler-version == '2.3.10' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' && matrix.bundler-version == '2.3' }}
       continue-on-error: true
       uses: paambaati/codeclimate-action@v3.0.0


### PR DESCRIPTION
Now that https://github.com/ruby/setup-ruby/issues/304 is merged and
released we can use minor version numbers.

Followup to https://github.com/ManageIQ/bundler-inject/pull/25#issuecomment-1086339078

@agrare Please review.