### PR TITLE
Add Ruby 3.1 and 3.2 to test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
         - '2.7'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
         ruby-version:
         - '2.7'
         - '3.0'
+        - '3.1'
+        - '3.2'
         bundler-version:
         - '2.1'
         - '2.2'
@@ -37,6 +39,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.0' && matrix.bundler-version == '2.4' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.2' && matrix.bundler-version == '2.4' }}
       continue-on-error: true
       uses: paambaati/codeclimate-action@v3.0.0

--- a/bundler-inject.gemspec
+++ b/bundler-inject.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "colorize"
   spec.add_development_dependency "manageiq-style"
-  spec.add_development_dependency "rake",          "~> 10.0"
-  spec.add_development_dependency "rspec",         "~> 3.0"
-  spec.add_development_dependency "simplecov",     ">= 0.21.2"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec",     "~> 3.0"
+  spec.add_development_dependency "simplecov", ">= 0.21.2"
 end

--- a/spec/bundler_inject_spec.rb
+++ b/spec/bundler_inject_spec.rb
@@ -261,14 +261,14 @@ RSpec.describe Bundler::Inject do
           bundle(:check)
 
           expect(out).to eq "The Gemfile's dependencies are satisfied\n"
-          expect(err).to be_empty
+          expect(err).to_not match %r{^\*\* override_gem}
         end
 
         it "bundle exec" do
           bundle("exec #{exec_command}")
 
           expect(out).to eq %Q{[["ansi", "1.4.3"], ["omg", "0.0.6"], ["rubytest", "0.7.0"]]\n}
-          expect(err).to be_empty
+          expect(err).to_not match %r{^\*\* override_gem}
         end
       end
 
@@ -288,14 +288,14 @@ RSpec.describe Bundler::Inject do
           bundle(:check)
 
           expect(out).to eq "The Gemfile's dependencies are satisfied\n"
-          expect(err).to match %r{\A\*\* override_gem\("ansi", "=1.4.2"\) at .+/bundler\.d/local_overrides\.rb:1\n\z}
+          expect(err).to match %r{^\*\* override_gem\("ansi", "=1.4.2"\) at .+/bundler\.d/local_overrides\.rb:1\n$}
         end
 
         it "bundle exec" do
           bundle("exec #{exec_command}")
 
           expect(out).to eq %Q{[["ansi", "1.4.2"], ["omg", "0.0.6"], ["rubytest", "0.7.0"]]\n}
-          expect(err).to match %r{\A\*\* override_gem\("ansi", "=1.4.2"\) at .+/bundler\.d/local_overrides\.rb:1\n\z}
+          expect(err).to match %r{^\*\* override_gem\("ansi", "=1.4.2"\) at .+/bundler\.d/local_overrides\.rb:1\n$}
         end
       end
 
@@ -315,14 +315,14 @@ RSpec.describe Bundler::Inject do
           bundle(:check)
 
           expect(out).to eq "The Gemfile's dependencies are satisfied\n"
-          expect(err).to match %r{\A\*\* override_gem\("ansi", "=1.4.2"\) at .+/\.bundler\.d/global_overrides\.rb:1\n\z}
+          expect(err).to match %r{^\*\* override_gem\("ansi", "=1.4.2"\) at .+/\.bundler\.d/global_overrides\.rb:1\n$}
         end
 
         it "bundle exec" do
           bundle("exec #{exec_command}")
 
           expect(out).to eq %Q{[["ansi", "1.4.2"], ["omg", "0.0.6"], ["rubytest", "0.7.0"]]\n}
-          expect(err).to match %r{\A\*\* override_gem\("ansi", "=1.4.2"\) at .+/\.bundler\.d/global_overrides\.rb:1\n\z}
+          expect(err).to match %r{^\*\* override_gem\("ansi", "=1.4.2"\) at .+/\.bundler\.d/global_overrides\.rb:1\n$}
         end
       end
     end


### PR DESCRIPTION
This PR also loosens regexes in specs to deal with other data on STDERR

In particular, newer Rubies (3.1, 3.2) combined with older bundlers
(2.1, 2.2) raise deprecation warnings to STDERR. The regex is too
strict, and doesn't ignore those errors.