### PR TITLE
Allow user to specify a PATH to search for gem overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ original declaration.
 
 ## Configuration
 
+### Disabling warnings
+
 To disable warnings that are output to the console when `override_gem` or
 `ensure_gem` is in use, you can update a bundler setting:
 
@@ -94,6 +96,32 @@ $ export BUNDLE_BUNDLER_INJECT__DISABLE_WARN_OVERRIDE_GEM=true
 
 There is a fallback for those that will check the `RAILS_ENV` environment
 variable, and will disable the warning when in `"production"`.
+
+### Specifying gem source directories
+
+Many developers checkout gems into a single directory for enhancement.
+Instead of specifying the full path of gems every time, specify a gem path
+to locate these directories. This can be defined with a bundler setting:
+
+```console
+$ bundle config bundler_inject.gem_path ~/src:~/gem_src
+```
+
+or use an environment variable:
+
+```console
+$ export BUNDLE_BUNDLER_INJECT__GEM_PATH=~/src:~/gem_src
+```
+
+An override will find a gem in either of these two directories or in the directory
+where the Gemfile override is located.
+
+```Gemfile
+# located in ~/src/ansi
+override_gem "ansi"
+# located in $PWD/mime_override
+override_gem "mime/type", path: "mime_override"
+```
 
 ## What is this sorcery?
 

--- a/spec/bundler_inject_spec.rb
+++ b/spec/bundler_inject_spec.rb
@@ -143,6 +143,44 @@ RSpec.describe Bundler::Inject do
           end
         end
 
+        it "with a filename path in a gem_path location" do
+          with_path_based_gem("https://github.com/rubyworks/ansi", "the_gem") do |path|
+            write_bundler_d_file <<~F
+              override_gem "ansi", :path => "the_gem"
+            F
+            bundle(:update, :env => {"BUNDLE_BUNDLER_INJECT__GEM_PATH" => path.dirname.to_s})
+
+            expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+            expect(err).to match %r{^\*\* override_gem\("ansi", :path=>#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
+          end
+        end
+
+        it "with no path in a gem_path location" do
+          with_path_based_gem("https://github.com/rubyworks/ansi", "ansi") do |path|
+            write_bundler_d_file <<~F
+              override_gem "ansi"
+            F
+            bundle(:update, :env => {"BUNDLE_BUNDLER_INJECT__GEM_PATH" => path.dirname.to_s})
+
+            expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+            expect(err).to match %r{^\*\* override_gem\("ansi", :path=>#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
+          end
+        end
+
+        it "with no path in a gem_path location and multiple paths" do
+          with_path_based_gem("https://github.com/rubyworks/ansi", "ansi") do |path|
+            Dir.mktmpdir do |empty_dir|
+              write_bundler_d_file <<~F
+                override_gem "ansi"
+              F
+              bundle(:update, :env => {"BUNDLE_BUNDLER_INJECT__GEM_PATH" => "/nonexistent-directory/:#{empty_dir.to_s}:#{path.dirname.to_s}"})
+
+              expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+              expect(err).to match %r{^\*\* override_gem\("ansi", :path=>#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
+            end
+          end
+        end
+
         it "when the gem doesn't exist" do
           write_bundler_d_file <<~F
             override_gem "omg"

--- a/spec/bundler_inject_spec.rb
+++ b/spec/bundler_inject_spec.rb
@@ -117,8 +117,8 @@ RSpec.describe Bundler::Inject do
           expect(err).to match %r{^\*\* override_gem\("ansi", :git=>"https://github.com/rubyworks/ansi"\) at .+/bundler\.d/local_overrides\.rb:1$}
         end
 
-        it "with a path" do
-          with_path_based_gem("https://github.com/rubyworks/ansi") do |path|
+        it "with an absolute path" do
+          with_path_based_gem("https://github.com/rubyworks/ansi", "the_gem") do |path|
             write_bundler_d_file <<~F
               override_gem "ansi", :path => #{path.to_s.inspect}
             F
@@ -129,8 +129,8 @@ RSpec.describe Bundler::Inject do
           end
         end
 
-        it "with a path that includes ~" do
-          with_path_based_gem("https://github.com/rubyworks/ansi") do |path|
+        it "with a full path that includes ~" do
+          with_path_based_gem("https://github.com/rubyworks/ansi", "the_gem") do |path|
             path = Pathname.new("~/#{path.relative_path_from(Pathname.new("~").expand_path)}")
 
             write_bundler_d_file <<~F

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -93,14 +93,14 @@ module Spec
       FileUtils.rm_rf(Helpers.global_bundler_d_dir)
     end
 
-    def with_path_based_gem(source_repo)
+    def with_path_based_gem(source_repo, dir_name)
       Dir.mktmpdir do |path|
         path = Pathname.new(path)
         Dir.chdir(path) do
-          out, status = Open3.capture2e("git clone --depth 1 #{source_repo} the_gem")
+          out, status = Open3.capture2e("git clone --depth 1 #{source_repo} #{dir_name}")
           raise "An error occured while cloning #{source_repo.inspect}...\n#{out}" unless status.exitstatus == 0
         end
-        path = path.join("the_gem")
+        path = path.join(dir_name)
 
         yield path
       end


### PR DESCRIPTION
This uses a PATH to locate an override gem.

The idea behind this is a developer has a common directory where they `git clone` gems and tweak them.


I think the 2 outstanding issues are:
- What do we call the override path?
- ~~When do we not want to override a path? (maybe the developer has a gem checked out but they are overriding it with a github repo?)~~ SOLUTION: only override if no options specified (or they provide a partial path)