### PR TITLE
Add ruby 3.3+/bundler 2.5+ to matrix, drop ruby 2.6/bundler 2.0-2.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,14 +17,13 @@ jobs:
         - '3.0'
         - '3.1'
         - '3.2'
+        - '3.3'
+        - '3.4'
         bundler-version:
-        - '2.1'
-        - '2.2'
-        - '2.3'
         - '2.4'
-        include:
-        - ruby-version: '2.6'
-          bundler-version: '2.0'
+        - '2.5'
+        - '2.6'
+        - '2.7'
     env:
       TEST_BUNDLER_VERSION: ${{ matrix.bundler-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
@@ -40,6 +39,6 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Report code coverage
-      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.2' && matrix.bundler-version == '2.4' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.4' && matrix.bundler-version == '2.7' }}
       continue-on-error: true
       uses: paambaati/codeclimate-action@v9

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,19 @@ jobs:
         - '2.5'
         - '2.6'
         - '2.7'
+        exclude:
+        - ruby-version: '2.7'
+          bundler-version: '2.5'
+        - ruby-version: '2.7'
+          bundler-version: '2.6'
+        - ruby-version: '3.0'
+          bundler-version: '2.6'
+        - ruby-version: '2.7'
+          bundler-version: '2.7'
+        - ruby-version: '3.0'
+          bundler-version: '2.7'
+        - ruby-version: '3.1'
+          bundler-version: '2.7'
     env:
       TEST_BUNDLER_VERSION: ${{ matrix.bundler-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/spec/bundler_inject_spec.rb
+++ b/spec/bundler_inject_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Bundler::Inject do
           bundle(:update)
 
           expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
-          expect(err).to match %r{^\*\* override_gem\("ansi", :git=>"https://github.com/rubyworks/ansi"\) at .+/bundler\.d/local_overrides\.rb:1$}
+          expect(err).to match %r{^\*\* override_gem\("ansi", (git: |:git=>)"https://github.com/rubyworks/ansi"\) at .+/bundler\.d/local_overrides\.rb:1$}
         end
 
         it "with an absolute path" do
@@ -125,7 +125,7 @@ RSpec.describe Bundler::Inject do
             bundle(:update)
 
             expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
-            expect(err).to match %r{^\*\* override_gem\("ansi", :path=>#{path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
+            expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
           end
         end
 
@@ -139,7 +139,7 @@ RSpec.describe Bundler::Inject do
             bundle(:update)
 
             expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
-            expect(err).to match %r{^\*\* override_gem\("ansi", :path=>#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
+            expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
           end
         end
 
@@ -151,7 +151,7 @@ RSpec.describe Bundler::Inject do
             bundle(:update, :env => {"BUNDLE_BUNDLER_INJECT__GEM_PATH" => path.dirname.to_s})
 
             expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
-            expect(err).to match %r{^\*\* override_gem\("ansi", :path=>#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
+            expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
           end
         end
 
@@ -163,7 +163,7 @@ RSpec.describe Bundler::Inject do
             bundle(:update, :env => {"BUNDLE_BUNDLER_INJECT__GEM_PATH" => path.dirname.to_s})
 
             expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
-            expect(err).to match %r{^\*\* override_gem\("ansi", :path=>#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
+            expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
           end
         end
 
@@ -176,7 +176,7 @@ RSpec.describe Bundler::Inject do
               bundle(:update, :env => {"BUNDLE_BUNDLER_INJECT__GEM_PATH" => "/nonexistent-directory/:#{empty_dir.to_s}:#{path.dirname.to_s}"})
 
               expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
-              expect(err).to match %r{^\*\* override_gem\("ansi", :path=>#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
+              expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
             end
           end
         end
@@ -271,7 +271,7 @@ RSpec.describe Bundler::Inject do
           bundle(:update)
 
           expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
-          expect(err).to match %r{^\*\* override_gem\("ansi", :git=>"https://github.com/rubyworks/ansi"\) at .+/\.bundler\.d/global_overrides\.rb:1$}
+          expect(err).to match %r{^\*\* override_gem\("ansi", (git: |:git=>)"https://github.com/rubyworks/ansi"\) at .+/\.bundler\.d/global_overrides\.rb:1$}
         end
       end
     end


### PR DESCRIPTION
Bundler 2.4 is the last version that supports pre-ruby 3.0 (2.6/2.7). Since ruby 3.0 can be a beast to upgrade, we might want to keep ruby 2.7 with bundler 2.4 in the matrix  as the "bridge" for anyone trying to upgrade to ruby 3.0.  We can choose to forcefully drop support later on.

Note, we can still claim to try to support older rubies/bundler but we should keep our test matrix limited to what we actively support.

Run code coverage against latest ruby and bundler.

Ruby 3.4 tests were failing due to a Hash#inspect change.  The tests were fixed to be ruby agnostic.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
