### PR TITLE
Fix specs after ansi upgraded to 1.6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-        - '2.7'
-        - '3.0'
         - '3.1'
         - '3.2'
         - '3.3'
@@ -33,22 +31,8 @@ jobs:
         - '2.7'
         - '4.0'
         exclude:
-        - ruby-version: '2.7'
-          bundler-version: '2.5'
-        - ruby-version: '2.7'
-          bundler-version: '2.6'
-        - ruby-version: '3.0'
-          bundler-version: '2.6'
-        - ruby-version: '2.7'
-          bundler-version: '2.7'
-        - ruby-version: '3.0'
-          bundler-version: '2.7'
         - ruby-version: '3.1'
           bundler-version: '2.7'
-        - ruby-version: '2.7'
-          bundler-version: '4.0'
-        - ruby-version: '3.0'
-          bundler-version: '4.0'
         - ruby-version: '3.1'
           bundler-version: '4.0'
     env:

--- a/spec/bundler_inject_spec.rb
+++ b/spec/bundler_inject_spec.rb
@@ -2,9 +2,9 @@
 # test various versions and overrides. rubytest 0.7.0 depends on ansi >= 0 which
 # has no dependencies.  This allows us to manipulate the various versions of
 # ansi without introducing additional dependencies complicating the test.
-# ansi 1.4.2, 1.4.3, 1.5.0 are the three latest versions, and most tests "start"
-# with ansi 1.4.3 in the base Gemfile. omg 0.0.6 is an additional gem that also
-# has no dependencies.
+# ansi 1.4.2, 1.4.3, 1.5.0, and 1.6.0 are available versions, and most tests
+# "start" with ansi 1.4.3 in the base Gemfile. omg 0.0.6 is an additional gem
+# that also has no dependencies.
 RSpec.describe Bundler::Inject do
   let(:bundler_inject_root) { Pathname.new(__dir__).join("..").expand_path.to_s }
   let(:base_gemfile) do
@@ -113,7 +113,7 @@ RSpec.describe Bundler::Inject do
           F
           bundle(:update)
 
-          expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+          expect(lockfile_specs).to eq [["ansi", "1.6.0"]]
           expect(err).to match %r{^\*\* override_gem\("ansi", (git: |:git=>)"https://github.com/rubyworks/ansi"\) at .+/bundler\.d/local_overrides\.rb:1$}
         end
 
@@ -124,7 +124,7 @@ RSpec.describe Bundler::Inject do
             F
             bundle(:update)
 
-            expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+            expect(lockfile_specs).to eq [["ansi", "1.6.0"]]
             expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
           end
         end
@@ -138,7 +138,7 @@ RSpec.describe Bundler::Inject do
             F
             bundle(:update)
 
-            expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+            expect(lockfile_specs).to eq [["ansi", "1.6.0"]]
             expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
           end
         end
@@ -150,7 +150,7 @@ RSpec.describe Bundler::Inject do
             F
             bundle(:update, :env => {"BUNDLE_BUNDLER_INJECT__GEM_PATH" => path.dirname.to_s})
 
-            expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+            expect(lockfile_specs).to eq [["ansi", "1.6.0"]]
             expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
           end
         end
@@ -162,7 +162,7 @@ RSpec.describe Bundler::Inject do
             F
             bundle(:update, :env => {"BUNDLE_BUNDLER_INJECT__GEM_PATH" => path.dirname.to_s})
 
-            expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+            expect(lockfile_specs).to eq [["ansi", "1.6.0"]]
             expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
           end
         end
@@ -175,7 +175,7 @@ RSpec.describe Bundler::Inject do
               F
               bundle(:update, :env => {"BUNDLE_BUNDLER_INJECT__GEM_PATH" => "/nonexistent-directory/:#{empty_dir.to_s}:#{path.dirname.to_s}"})
 
-              expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+              expect(lockfile_specs).to eq [["ansi", "1.6.0"]]
               expect(err).to match %r{^\*\* override_gem\("ansi", (path: |:path=>)#{path.expand_path.to_s.inspect}\) at .+/bundler\.d/local_overrides\.rb:1$}
             end
           end
@@ -270,7 +270,7 @@ RSpec.describe Bundler::Inject do
           F
           bundle(:update)
 
-          expect(lockfile_specs).to eq [["ansi", "1.5.0"]]
+          expect(lockfile_specs).to eq [["ansi", "1.6.0"]]
           expect(err).to match %r{^\*\* override_gem\("ansi", (git: |:git=>)"https://github.com/rubyworks/ansi"\) at .+/\.bundler\.d/global_overrides\.rb:1$}
         end
       end


### PR DESCRIPTION
Closes #51

@agrare Please review.
- ~Turns out ansi 1.6.0 does not have dependencies and I just read it wrong, so this is just a simple spec update.~
- ~It turns out we _do_ need a different gem because ansi 1.6.0 set a minimum Ruby version of 3.1, which breaks the support for older Ruby versions.~
- It's difficult to find a gem combination, so instead I'm dropping support for older Ruby versions, at least in CI.